### PR TITLE
fix(tokens): Properly handle special characters

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -6,8 +6,9 @@ pub(crate) fn generate_token<S: AsRef<str>>(text: S) -> Result<String, Errors> {
     let b = tkk().0;
 
     let mut d = vec![];
-
-    for mut f in 0..text.as_ref().len() {
+    let actual_text_len = text.as_ref().encode_utf16().count();
+    
+    for mut f in 0..actual_text_len {
         let a: Vec<u16> = text.as_ref().encode_utf16().collect();
         let mut g = a[f] as i64;
 
@@ -18,7 +19,7 @@ pub(crate) fn generate_token<S: AsRef<str>>(text: S) -> Result<String, Errors> {
                 d.push(g >> 6 | 192);
             } else {
                 if (55296 == (g & 64512))
-                    && (f + 1 < text.as_ref().len())
+                    && (f + 1 < actual_text_len)
                     && (56320 == (a[f + 1] & 64512))
                 {
                     f += 1;


### PR DESCRIPTION
Currently when trying to translate sentences using special characters (such as ó, á, é, ...) the token generator fails as rust's String::len() counts _bytes_ and not the characters in the string.

- related [stackoverflow](https://stackoverflow.com/questions/71720398/stringfrom-a-string-literal-differs-in-length-for-o-and-%C3%B3-why)

I tested this code with `Acá intentaré responder si es tarde para aprender a programar y que profesión debes estudiar para ser un ingeniero world class.` and it worked.